### PR TITLE
Quickstart guide and link from the documentation home

### DIFF
--- a/docker/index.md
+++ b/docker/index.md
@@ -39,9 +39,9 @@ Documentation about installation: https://docs.docker.com/engine/installation
 
 ## Quickstart
 
-After you installed docker you should able to run `docker` and `docker-compose` in your terminal/command line tool. For quickly boot up a project you will need to create one file in your code root folder: `docker-compose.yml`
+After you installed docker you should able to run `docker` and `docker-compose` in your terminal/command line tool. For quickly boot up a project you will need to create one file in your project root folder: `docker-compose.yml` with this basic configuration:
 ```yaml
-version: "3"
+version: "2"
 services:
   web:
     image: phpearth/php:7.1-apache
@@ -51,12 +51,14 @@ services:
       - 8080:80
 ```
 
-For running open your project folder in command line and call: `docker-compose up`
+For running it open your project folder in command line and call: `docker-compose up`
 
 It will download the group image and start your server, it will link your project folder with the default server root and it will bound the server http output to your machine :8080 port.
 
 After it's started check your http://localhost:8080 url and you should able to start develop your project.
 > Note: You should bound a `src` folder into the container instead the whole project by replacing the ./ to ./src
+
+For more options check the documentation: https://docs.docker.com/compose/compose-file/#reference-and-guidelines
 
 ## See also
 

--- a/docker/index.md
+++ b/docker/index.md
@@ -37,6 +37,27 @@ Documentation about installation: https://docs.docker.com/engine/installation
 * [Alpine PHP.earth repository](/docker/alpine-php-earth.md)
 * [Docker recipes](/docker/recipes.md)
 
+## Quickstart
+
+After you installed docker you should able to run `docker` and `docker-compose` in your terminal/command line tool. For quickly boot up a project you will need to create one file in your code root folder: `docker-compose.yml`
+```yaml
+version: "3"
+services:
+  web:
+    image: phpearth/php:7.1-apache
+    volumes:
+      - ./:/var/www/localhost/htdocs
+    ports:
+      - 8080:80
+```
+
+For running open your project folder in command line and call: `docker-compose up`
+
+It will download the group image and start your server, it will link your project folder with the default server root and it will bound the server http output to your machine :8080 port.
+
+After it's started check your http://localhost:8080 url and you should able to start develop your project.
+> Note: You should bound a `src` folder into the container instead the whole project by replacing the ./ to ./src
+
 ## See also
 
 Recommended additional resources when learning Docker for PHP development:

--- a/docker/index.md
+++ b/docker/index.md
@@ -64,6 +64,7 @@ For more options check the documentation: https://docs.docker.com/compose/compos
 
 Recommended additional resources when learning Docker for PHP development:
 
+* [Official Docker Documentation](https://docs.docker.com/)
 * [Official Docker PHP images](https://hub.docker.com/_/php/)
 * [Awesome Docker](https://github.com/veggiemonk/awesome-docker) - A curated list
   of Docker resources and projects

--- a/docker/index.md
+++ b/docker/index.md
@@ -58,7 +58,7 @@ It will download the group image and start your server, it will link your projec
 After it's started check your http://localhost:8080 url and you should able to start develop your project.
 > Note: You should bound a `src` folder into the container instead the whole project by replacing the ./ to ./src
 
-For more options check the documentation: https://docs.docker.com/compose/compose-file/#reference-and-guidelines
+For more options check the documentation: https://docs.docker.com/compose/compose-file
 
 ## See also
 

--- a/index.md
+++ b/index.md
@@ -13,6 +13,7 @@ best practices and frequently asked questions about PHP.
 * [Why choose PHP?](/intro/why-php.md)
 * [Which books are recommended for learning PHP?](/intro/books.md)
 * [Which hosting service should I use for PHP? Are there any free hosting providers?](/intro/hosting.md)
+* [Developing on your machine with Docker](/docker/index.md)
 * [PHP basics](/intro/basics.md)
 * [PHP 7](/intro/php7.md)
 * [PHP versions usage](/intro/versions.md)


### PR DESCRIPTION
* Adding link about docker to the documentation home page
* Creating a quickstart guide with docker-compose
* Adding more references to the official docker documentation